### PR TITLE
Add an fd-send-recv dependency to the opam file

### DIFF
--- a/opam
+++ b/opam
@@ -22,6 +22,7 @@ depends: [
   "alcotest" {test}
   "base-bytes"
   "unix-errno"
+  "fd-send-recv"
 ]
 depopts: [
   "base-unix"


### PR DESCRIPTION
This fixes the build.  Since `fd-send-recv` is only used for converting `file_descr` values to ints, it would be worth considering using [unix-type-representations](https://opam.ocaml.org/packages/unix-type-representations/unix-type-representations.0.1.0/) instead.
