### PR TITLE
Re-expose some system call bindings

### DIFF
--- a/lib_gen/unix_sys_stat_bindings.ml
+++ b/lib_gen/unix_sys_stat_bindings.ml
@@ -16,7 +16,7 @@
  *)
 
 open Ctypes
-open PosixTypes
+open Posix_types
 
 module Types = Unix_sys_stat_types.C(Unix_sys_stat_types_detected)
 

--- a/opam
+++ b/opam
@@ -26,6 +26,7 @@ depends: [
   "unix-errno" {>= "0.4.0"}
   "ctypes"
   "posix-types"
+  "unix-type-representations"
 ]
 depopts: [
   "base-unix"

--- a/src/_tags
+++ b/src/_tags
@@ -1,2 +1,3 @@
-<sys_stat_map.*>: package(ctypes.stubs), use_sys_stat_stubs, package(unix-errno.unix), package(posix-types)
+<sys_stat_map.*>: package(ctypes.stubs), use_sys_stat_stubs, package(unix-errno.unix)
+<sys_stat_map.*>: package(posix-types), package(unix-type-representations)
 true: package(bytes)

--- a/unix/_tags
+++ b/unix/_tags
@@ -1,3 +1,4 @@
 <*.*>: package(bytes), package(ctypes.stubs), package(unix-errno.unix), package(posix-types)
 <unix_sys_stat_stubs.c>: use_ctypes, use_sys_stat_util
+<*.{ml,mli}>: package(unix-type-representations)
 <*.{cma,cmxa}>: use_sys_stat_stubs

--- a/unix/sys_stat_unix.ml
+++ b/unix/sys_stat_unix.ml
@@ -154,14 +154,15 @@ let mknod name mode ~dev =
     else Some ()
   )
 
-(*
 let stat name =
   Errno_unix.raise_on_errno ~call:"stat" ~label:name (fun () ->
     let stat = Ctypes.make Type.Stat.t in
-    ignore (C.stat name (Ctypes.addr stat));
-    stat
+    if C.stat name (Ctypes.addr stat) <> 0
+    then None
+    else Some stat
   )
 
+(*
 let lstat name =
   Errno_unix.raise_on_errno ~call:"lstat" ~label:name (fun () ->
     let stat = Ctypes.make Type.Stat.t in

--- a/unix/sys_stat_unix.ml
+++ b/unix/sys_stat_unix.ml
@@ -162,14 +162,15 @@ let stat name =
     else Some stat
   )
 
-(*
 let lstat name =
   Errno_unix.raise_on_errno ~call:"lstat" ~label:name (fun () ->
     let stat = Ctypes.make Type.Stat.t in
-    ignore (C.lstat name (Ctypes.addr stat));
-    stat
+    if C.lstat name (Ctypes.addr stat) <> 0
+    then None
+    else Some stat
   )
 
+(*
 let fstat fd =
   Errno_unix.raise_on_errno ~call:"fstat" (fun () ->
     let stat = Ctypes.make Type.Stat.t in

--- a/unix/sys_stat_unix.ml
+++ b/unix/sys_stat_unix.ml
@@ -179,14 +179,15 @@ let fstat fd =
     else Some stat
   )
 
-(*
 let chmod name mode =
   Errno_unix.raise_on_errno ~call:"chmod" ~label:name (fun () ->
-    (*let mode = Int32.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in*)
-    let mode = Ctypes.(coerce uint32_t PosixTypes.mode_t Unsigned.UInt32.zero) in
-    ignore (C.chmod name mode)
+    let mode = Posix_types.Mode.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in
+    if C.chmod name mode <> 0
+    then None
+    else Some ()
   )
 
+(*
 let fchmod fd mode =
   Errno_unix.raise_on_errno ~call:"fchmod" (fun () ->
     (*let mode = Int32.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in*)

--- a/unix/sys_stat_unix.ml
+++ b/unix/sys_stat_unix.ml
@@ -137,15 +137,13 @@ module Stat = struct
 
 end
 
-(*
 let mkdir name mode =
   Errno_unix.raise_on_errno ~call:"mkdir" ~label:name (fun () ->
-    (*let mode = Int32.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in*)
-    let mode = Ctypes.(coerce uint32_t PosixTypes.mode_t Unsigned.UInt32.zero) in
-    ignore (C.mkdir name mode)
+    let mode = Posix_types.Mode.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in
+    if C.mkdir name mode <> 0
+    then None
+    else Some ()
   )
-    
-*)
 
 let mknod name mode ~dev =
   Errno_unix.raise_on_errno ~call:"mknod" ~label:name (fun () ->

--- a/unix/sys_stat_unix.ml
+++ b/unix/sys_stat_unix.ml
@@ -170,14 +170,16 @@ let lstat name =
     else Some stat
   )
 
-(*
+
 let fstat fd =
   Errno_unix.raise_on_errno ~call:"fstat" (fun () ->
     let stat = Ctypes.make Type.Stat.t in
-    ignore (C.fstat (Fd_send_recv.int_of_fd fd) (Ctypes.addr stat));
-    stat
+    if C.fstat (Unix_representations.int_of_file_descr fd) (Ctypes.addr stat) <> 0
+    then None
+    else Some stat
   )
 
+(*
 let chmod name mode =
   Errno_unix.raise_on_errno ~call:"chmod" ~label:name (fun () ->
     (*let mode = Int32.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in*)

--- a/unix/sys_stat_unix.ml
+++ b/unix/sys_stat_unix.ml
@@ -187,11 +187,10 @@ let chmod name mode =
     else Some ()
   )
 
-(*
 let fchmod fd mode =
   Errno_unix.raise_on_errno ~call:"fchmod" (fun () ->
-    (*let mode = Int32.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in*)
-    let mode = Ctypes.(coerce uint32_t PosixTypes.mode_t Unsigned.UInt32.zero) in
-    ignore (C.fchmod (Fd_send_recv.int_of_fd fd) mode)
+    let mode = Posix_types.Mode.of_int (Sys_stat.Mode.to_code ~host:Mode.host mode) in
+    if C.fchmod (Unix_representations.int_of_file_descr fd) mode <> 0
+    then None
+    else Some ()
   )
-*)

--- a/unix/sys_stat_unix.mli
+++ b/unix/sys_stat_unix.mli
@@ -59,9 +59,9 @@ val stat : string -> Stat.t
 
 val lstat : string -> Stat.t
 
-(*
 val fstat : Unix.file_descr -> Stat.t
 
+(*
 val chmod : string -> Sys_stat.Mode.t -> unit
 
 val fchmod : Unix.file_descr -> Sys_stat.Mode.t -> unit

--- a/unix/sys_stat_unix.mli
+++ b/unix/sys_stat_unix.mli
@@ -57,9 +57,9 @@ val mknod : string -> Sys_stat.Mode.t -> dev:int -> unit
 
 val stat : string -> Stat.t
 
-(*
 val lstat : string -> Stat.t
 
+(*
 val fstat : Unix.file_descr -> Stat.t
 
 val chmod : string -> Sys_stat.Mode.t -> unit

--- a/unix/sys_stat_unix.mli
+++ b/unix/sys_stat_unix.mli
@@ -61,8 +61,8 @@ val lstat : string -> Stat.t
 
 val fstat : Unix.file_descr -> Stat.t
 
-(*
 val chmod : string -> Sys_stat.Mode.t -> unit
 
+(*
 val fchmod : Unix.file_descr -> Sys_stat.Mode.t -> unit
 *)

--- a/unix/sys_stat_unix.mli
+++ b/unix/sys_stat_unix.mli
@@ -54,9 +54,10 @@ end
 val mkdir : string -> Sys_stat.Mode.t -> unit
 
 val mknod : string -> Sys_stat.Mode.t -> dev:int -> unit
-(*
+
 val stat : string -> Stat.t
 
+(*
 val lstat : string -> Stat.t
 
 val fstat : Unix.file_descr -> Stat.t

--- a/unix/sys_stat_unix.mli
+++ b/unix/sys_stat_unix.mli
@@ -63,6 +63,5 @@ val fstat : Unix.file_descr -> Stat.t
 
 val chmod : string -> Sys_stat.Mode.t -> unit
 
-(*
 val fchmod : Unix.file_descr -> Sys_stat.Mode.t -> unit
-*)
+

--- a/unix/sys_stat_unix.mli
+++ b/unix/sys_stat_unix.mli
@@ -51,8 +51,7 @@ module Stat : sig
   val to_unix : host:Sys_stat.Host.t -> t -> Unix.LargeFile.stats
 end
 
-(* val mkdir : string -> Sys_stat.Mode.t -> unit *)
-
+val mkdir : string -> Sys_stat.Mode.t -> unit
 
 val mknod : string -> Sys_stat.Mode.t -> dev:int -> unit
 (*


### PR DESCRIPTION
Re-expose the previously-disabled bindings to [`mkdir`](e8714c95), [`stat`](b6c4f193), [`lstat`](295950748f00fe0900fc9afb79ef921a4646b8a5), [`fstat`](16cfdaffe5663ec7b740fde9041f27498870c63b), [`chmod`](76513927dfc2f6825aa1efa3a980b34de81fc7c9) and [`fchmod`](df83d87cd1b569f5a70615ab5ccc8f204acd548d).  There are a few small improvements to the last time the bindings were active:
* Error checking uses the new unix-errno interface (https://github.com/dsheets/ocaml-unix-errno/pull/7)
* Argument conversions are based on the safe functions in [posix-types](https://travis-ci.org/yallop/ocaml-posix-types) instead of `Ctypes.coerce`
* The bindings use the new `struct stat` definition (#14)
* Conversions between file handles and integers use the [unix-type-representations](https://github.com/yallop/ocaml-unix-type-representations) package.
